### PR TITLE
Migrate to quarkus 3.3.0 - Quarkus made changes in datasource interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ As [Clement Escoffier](https://github.com/cescoffier) had point out in [#20471](
 
 Please pick corresponding version with Quarkus version:
 
-|Quarkus|Reactive H2 Client|
-|---|---|
-|2|0.1.x|
-|3|0.2.x|
+| Quarkus       | Reactive H2 Client |
+|---------------|--------------------|
+| 2             | 0.1.x              |
+| 3.0.0 - 3.2.x | 0.2.x              |
+| 3.3.x         | 0.3.x              |
 
 Notice: DevService not supported yet.
 

--- a/deployment/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/deployment/ReactiveH2ClientProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/deployment/ReactiveH2ClientProcessor.java
@@ -71,10 +71,13 @@ class ReactiveH2ClientProcessor {
                 dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
 
         for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
-            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, h2Pool, vertxPool, syntheticBeans, dataSourceName,
-                    dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
-                    dataSourcesReactiveRuntimeConfig, dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems,
-                    curateOutcomeBuildItem);
+            if (!DataSourceUtil.DEFAULT_DATASOURCE_NAME.equals(dataSourceName)) {
+                createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, h2Pool, vertxPool, syntheticBeans,
+                        dataSourceName,
+                        dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
+                        dataSourcesReactiveRuntimeConfig, dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems,
+                        curateOutcomeBuildItem);
+            }
         }
 
         return new ServiceStartBuildItem(FEATURE);

--- a/deployment/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/deployment/ReactiveH2ClientProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/deployment/ReactiveH2ClientProcessor.java
@@ -70,7 +70,7 @@ class ReactiveH2ClientProcessor {
                 dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig, dataSourcesReactiveRuntimeConfig,
                 dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
 
-        for (String dataSourceName : dataSourcesBuildTimeConfig.namedDataSources.keySet()) {
+        for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
             createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, h2Pool, vertxPool, syntheticBeans, dataSourceName,
                     dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
                     dataSourcesReactiveRuntimeConfig, dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems,
@@ -103,7 +103,7 @@ class ReactiveH2ClientProcessor {
 
         healthChecks.produce(
                 new HealthBuildItem("io.quarkiverse.quarkus.reactive.h2.client.runtime.health.ReactiveH2DataSourcesHealthCheck",
-                        dataSourcesBuildTimeConfig.healthEnabled));
+                        dataSourcesBuildTimeConfig.healthEnabled()));
     }
 
     @BuildStep
@@ -178,21 +178,21 @@ class ReactiveH2ClientProcessor {
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
         DataSourceBuildTimeConfig dataSourceBuildTimeConfig = dataSourcesBuildTimeConfig
-                .getDataSourceRuntimeConfig(dataSourceName);
+                .dataSources().get(dataSourceName);
         DataSourceReactiveBuildTimeConfig dataSourceReactiveBuildTimeConfig = dataSourcesReactiveBuildTimeConfig
                 .getDataSourceReactiveBuildTimeConfig(dataSourceName);
 
-        Optional<String> dbKind = DefaultDataSourceDbKindBuildItem.resolve(dataSourceBuildTimeConfig.dbKind,
+        Optional<String> dbKind = DefaultDataSourceDbKindBuildItem.resolve(dataSourceBuildTimeConfig.dbKind(),
                 defaultDataSourceDbKindBuildItems,
-                !DataSourceUtil.isDefault(dataSourceName) || dataSourceBuildTimeConfig.devservices.enabled
-                        .orElse(dataSourcesBuildTimeConfig.namedDataSources.isEmpty()),
+                !DataSourceUtil.isDefault(dataSourceName) || dataSourceBuildTimeConfig.devservices().enabled()
+                        .orElse(dataSourcesBuildTimeConfig.dataSources().isEmpty()),
                 curateOutcomeBuildItem);
 
         if (!dbKind.isPresent()) {
             return false;
         }
 
-        return DatabaseKind.isH2(dbKind.get()) && dataSourceReactiveBuildTimeConfig.enabled;
+        return DatabaseKind.isH2(dbKind.get()) && dataSourceReactiveBuildTimeConfig.enabled();
     }
 
     private boolean hasPools(DataSourcesBuildTimeConfig dataSourcesBuildTimeConfig,
@@ -204,7 +204,7 @@ class ReactiveH2ClientProcessor {
             return true;
         }
 
-        for (String dataSourceName : dataSourcesBuildTimeConfig.namedDataSources.keySet()) {
+        for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
             if (isReactiveH2PoolDefined(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig,
                     dataSourceName, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem)) {
                 return true;

--- a/deployment/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/deployment/ReactiveH2ClientProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/deployment/ReactiveH2ClientProcessor.java
@@ -65,19 +65,12 @@ class ReactiveH2ClientProcessor {
 
         feature.produce(new FeatureBuildItem(FEATURE));
 
-        createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, h2Pool, vertxPool, syntheticBeans,
-                DataSourceUtil.DEFAULT_DATASOURCE_NAME, dataSourcesBuildTimeConfig,
-                dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig, dataSourcesReactiveRuntimeConfig,
-                dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem);
-
         for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
-            if (!DataSourceUtil.DEFAULT_DATASOURCE_NAME.equals(dataSourceName)) {
-                createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, h2Pool, vertxPool, syntheticBeans,
-                        dataSourceName,
-                        dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
-                        dataSourcesReactiveRuntimeConfig, dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems,
-                        curateOutcomeBuildItem);
-            }
+            createPoolIfDefined(recorder, vertx, eventLoopCount, shutdown, h2Pool, vertxPool, syntheticBeans,
+                    dataSourceName,
+                    dataSourcesBuildTimeConfig, dataSourcesRuntimeConfig, dataSourcesReactiveBuildTimeConfig,
+                    dataSourcesReactiveRuntimeConfig, dataSourcesReactiveH2Config, defaultDataSourceDbKindBuildItems,
+                    curateOutcomeBuildItem);
         }
 
         return new ServiceStartBuildItem(FEATURE);
@@ -202,11 +195,6 @@ class ReactiveH2ClientProcessor {
             DataSourcesReactiveBuildTimeConfig dataSourcesReactiveBuildTimeConfig,
             List<DefaultDataSourceDbKindBuildItem> defaultDataSourceDbKindBuildItems,
             CurateOutcomeBuildItem curateOutcomeBuildItem) {
-        if (isReactiveH2PoolDefined(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig,
-                DataSourceUtil.DEFAULT_DATASOURCE_NAME, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem)) {
-            return true;
-        }
-
         for (String dataSourceName : dataSourcesBuildTimeConfig.dataSources().keySet()) {
             if (isReactiveH2PoolDefined(dataSourcesBuildTimeConfig, dataSourcesReactiveBuildTimeConfig,
                     dataSourceName, defaultDataSourceDbKindBuildItems, curateOutcomeBuildItem)) {

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.2.2.Final</quarkus.version>
+    <quarkus.version>3.3.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/runtime/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/runtime/H2PoolRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/quarkus/reactive/h2/client/runtime/H2PoolRecorder.java
@@ -38,7 +38,7 @@ public class H2PoolRecorder {
 
         JDBCPool h2Pool = initialize(vertx.getValue(),
                 eventLoopCount.get(),
-                dataSourcesRuntimeConfig.getDataSourceRuntimeConfig(dataSourceName),
+                dataSourcesRuntimeConfig.dataSources().get(dataSourceName),
                 dataSourcesReactiveRuntimeConfig.getDataSourceReactiveRuntimeConfig(dataSourceName),
                 dataSourcesReactiveH2Config.getDataSourceReactiveRuntimeConfig(dataSourceName));
 
@@ -68,20 +68,20 @@ public class H2PoolRecorder {
             DataSourceReactiveH2Config dataSourceReactiveH2Config) {
         PoolOptions poolOptions = new PoolOptions();
 
-        poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize);
+        poolOptions.setMaxSize(dataSourceReactiveRuntimeConfig.maxSize());
 
-        if (dataSourceReactiveRuntimeConfig.idleTimeout.isPresent()) {
-            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout.get().toMillis());
+        if (dataSourceReactiveRuntimeConfig.idleTimeout().isPresent()) {
+            int idleTimeout = Math.toIntExact(dataSourceReactiveRuntimeConfig.idleTimeout().get().toMillis());
             poolOptions.setIdleTimeout(idleTimeout).setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
         }
 
-        if (dataSourceReactiveRuntimeConfig.shared) {
+        if (dataSourceReactiveRuntimeConfig.shared()) {
             poolOptions.setShared(true);
-            dataSourceReactiveRuntimeConfig.name.ifPresent(poolOptions::setName);
+            dataSourceReactiveRuntimeConfig.name().ifPresent(poolOptions::setName);
         }
 
-        if (dataSourceReactiveRuntimeConfig.eventLoopSize.isPresent()) {
-            poolOptions.setEventLoopSize(Math.max(0, dataSourceReactiveRuntimeConfig.eventLoopSize.getAsInt()));
+        if (dataSourceReactiveRuntimeConfig.eventLoopSize().isPresent()) {
+            poolOptions.setEventLoopSize(Math.max(0, dataSourceReactiveRuntimeConfig.eventLoopSize().getAsInt()));
         } else if (eventLoopCount != null) {
             poolOptions.setEventLoopSize(Math.max(0, eventLoopCount));
         }
@@ -98,9 +98,9 @@ public class H2PoolRecorder {
             DataSourceReactiveRuntimeConfig dataSourceReactiveRuntimeConfig,
             DataSourceReactiveH2Config dataSourceReactiveH2Config) {
         JDBCConnectOptions connectOptions = new JDBCConnectOptions();
-        if (dataSourceReactiveRuntimeConfig.url.isPresent()) {
+        if (dataSourceReactiveRuntimeConfig.url().isPresent()) {
             // Only one URL is supported by JDBCPool
-            String url = dataSourceReactiveRuntimeConfig.url.get().get(0);
+            String url = dataSourceReactiveRuntimeConfig.url().get().get(0);
             // clean up the URL to make migrations easier
             if (url.startsWith("vertx-reactive:h2:")) {
                 url = url.substring("vertx-reactive:".length());
@@ -108,14 +108,14 @@ public class H2PoolRecorder {
             connectOptions.setJdbcUrl("jdbc:" + url);
         }
 
-        dataSourceRuntimeConfig.username.ifPresent(connectOptions::setUser);
-        dataSourceRuntimeConfig.password.ifPresent(connectOptions::setPassword);
+        dataSourceRuntimeConfig.username().ifPresent(connectOptions::setUser);
+        dataSourceRuntimeConfig.password().ifPresent(connectOptions::setPassword);
 
         // credentials provider
-        if (dataSourceRuntimeConfig.credentialsProvider.isPresent()) {
-            String beanName = dataSourceRuntimeConfig.credentialsProviderName.orElse(null);
+        if (dataSourceRuntimeConfig.credentialsProvider().isPresent()) {
+            String beanName = dataSourceRuntimeConfig.credentialsProviderName().orElse(null);
             CredentialsProvider credentialsProvider = CredentialsProviderFinder.find(beanName);
-            String name = dataSourceRuntimeConfig.credentialsProvider.get();
+            String name = dataSourceRuntimeConfig.credentialsProvider().get();
             Map<String, String> credentials = credentialsProvider.getCredentials(name);
             String user = credentials.get(USER_PROPERTY_NAME);
             String password = credentials.get(PASSWORD_PROPERTY_NAME);


### PR DESCRIPTION
The Quarkus 3.3.0 made some changes in datasource interfaces (e.g.: DataSourcesReactiveBuildTimeConfig) and it is necessary to adapt the code to these changes.